### PR TITLE
Use utf-8 in %encode-base64 and %decode-base64

### DIFF
--- a/modules/template-formatter.js
+++ b/modules/template-formatter.js
@@ -17026,13 +17026,29 @@ async function evalTemplate(template = "", options, content, doc, context = {}) 
 		// eslint-disable-next-line no-unused-vars
 		"stringify": value => { try { return JSON.stringify(value); } catch (error) { return value; } },
 		"encode-base64": value => {
-			const valueInUTF8 = new TextEncoder().encode(value);
-			return valueInUTF8.toBase64();
+			// can be replaced with Uint8Array.toBase64() which should already be supported by most browsers
+			// function taken from https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa
+			function bytesToBase64(bytes) {
+				const binString = Array.from(bytes, (byte) =>
+					String.fromCodePoint(byte),
+				).join("");
+				return btoa(binString);
+			}
+
+			const utf8Array = new TextEncoder().encode(value);
+			return bytesToBase64(utf8Array);
 		},
 		"decode-base64": value => {
+			// can be replaced with Uint8Array.fromBase64() which should already be supported by most browsers
+			// function taken from https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa
+			function base64ToBytes(base64) {
+				const binString = atob(base64);
+				return Uint8Array.from(binString, (m) => m.codePointAt(0));
+			}
+
 			try {
-				const bytes = Uint8Array.fromBase64(value);
-				return new TextDecoder("utf-8").decode(bytes);
+				const utf8Array = base64ToBytes(value);
+				return new TextDecoder("utf-8").decode(utf8Array);
 				// eslint-disable-next-line no-unused-vars
 			} catch(error) {
 				return value;

--- a/modules/template-formatter.js
+++ b/modules/template-formatter.js
@@ -17025,10 +17025,19 @@ async function evalTemplate(template = "", options, content, doc, context = {}) 
 		},
 		// eslint-disable-next-line no-unused-vars
 		"stringify": value => { try { return JSON.stringify(value); } catch (error) { return value; } },
-		// eslint-disable-next-line no-unused-vars
-		"encode-base64": value => { try { return btoa(value); } catch (error) { return value; } },
-		// eslint-disable-next-line no-unused-vars
-		"decode-base64": value => { try { return atob(value); } catch (error) { return value; } },
+		"encode-base64": value => {
+			const valueInUTF8 = new TextEncoder().encode(value);
+			return valueInUTF8.toBase64();
+		},
+		"decode-base64": value => {
+			try {
+				const bytes = Uint8Array.fromBase64(value);
+				return new TextDecoder("utf-8").decode(bytes);
+				// eslint-disable-next-line no-unused-vars
+			} catch(error) {
+				return value;
+			}
+		},
 		// eslint-disable-next-line no-unused-vars
 		"encode-uri": value => { try { return encodeURI(value); } catch (error) { return value; } },
 		// eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Hey, I modified the implementation of `%encode-base64` and `%decode-base64` so they work with all Unicode strings. (I was using `%encode-base64<{page-title}>` but when the title contained non-ASCII chars decoding as UTF-8 would fail.) Also see <https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings>.